### PR TITLE
Configure cell

### DIFF
--- a/AutocompleteTextfieldSwift.podspec
+++ b/AutocompleteTextfieldSwift.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name          = "AutocompleteTextfieldSwift"
+  s.version       = "2.0"
+  s.summary       = "Simple and straightforward sublass of UITextfield to manage string suggestions"
+  s.homepage      = "https://github.com/mnbayan/AutocompleteTextfieldSwift"
+  s.license       = { :type => 'MIT', :file => 'LICENSE' }
+  s.author        = { "mnbayan" => "mylenebayan@gmail.com" }
+  s.platform      = :ios, '8.0'
+  s.source        = { :git => "https://github.com/mnbayan/AutocompleteTextfieldSwift.git", :tag => "v#{s.version}" }
+  s.source_files  = 'Classes', 'AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift'
+  s.requires_arc  = true
+  s.framework     = "UIKit"
+end

--- a/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
+++ b/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
@@ -18,6 +18,8 @@ public class AutoCompleteTextField:UITextField {
     public var onSelect:(String, NSIndexPath)->() = {_,_ in}
     /// Handles textfield's textchanged
     public var onTextChange:(String)->() = {_ in}
+    /// Allows you to configure the table cell
+    public var configureCell:((tableView: UITableView, cellForRowAtIndexPath: NSIndexPath) -> UITableViewCell)?
     
     /// Font for the text suggestions
     public var autoCompleteTextFont = UIFont.systemFontOfSize(12)
@@ -154,23 +156,27 @@ extension AutoCompleteTextField: UITableViewDataSource, UITableViewDelegate {
     }
     
     public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cellIdentifier = "autocompleteCellIdentifier"
-        var cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier)
-        if cell == nil{
-            cell = UITableViewCell(style: .Default, reuseIdentifier: cellIdentifier)
+        if let configureCell = configureCell {
+            return configureCell(tableView: tableView, cellForRowAtIndexPath: indexPath)
+        } else {
+            let cellIdentifier = "autocompleteCellIdentifier"
+            var cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier)
+            if cell == nil{
+                cell = UITableViewCell(style: .Default, reuseIdentifier: cellIdentifier)
+            }
+            
+            if enableAttributedText{
+                cell?.textLabel?.attributedText = attributedAutoCompleteStrings[indexPath.row]
+            }
+            else{
+                cell?.textLabel?.font = autoCompleteTextFont
+                cell?.textLabel?.textColor = autoCompleteTextColor
+                cell?.textLabel?.text = autoCompleteStrings![indexPath.row]
+            }
+            
+            cell?.contentView.gestureRecognizers = nil
+            return cell!
         }
-        
-        if enableAttributedText{
-            cell?.textLabel?.attributedText = attributedAutoCompleteStrings[indexPath.row]
-        }
-        else{
-            cell?.textLabel?.font = autoCompleteTextFont
-            cell?.textLabel?.textColor = autoCompleteTextColor
-            cell?.textLabel?.text = autoCompleteStrings![indexPath.row]
-        }
-        
-        cell?.contentView.gestureRecognizers = nil
-        return cell!
     }
     
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
+++ b/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
@@ -9,49 +9,49 @@
 import Foundation
 import UIKit
 
-public class AutoCompleteTextField:UITextField {
+open class AutoCompleteTextField:UITextField {
     /// Manages the instance of tableview
-    private var autoCompleteTableView:UITableView?
+    fileprivate var autoCompleteTableView:UITableView?
     /// Holds the collection of attributed strings
-    private lazy var attributedAutoCompleteStrings = [NSAttributedString]()
+    fileprivate lazy var attributedAutoCompleteStrings = [NSAttributedString]()
     /// Handles user selection action on autocomplete table view
-    public var onSelect:(String, NSIndexPath)->() = {_,_ in}
+    open var onSelect:(String, IndexPath)->() = {_,_ in}
     /// Handles textfield's textchanged
-    public var onTextChange:(String)->() = {_ in}
+    open var onTextChange:(String)->() = {_ in}
     /// Allows you to configure the table cell
-    public var configureCell:((tableView: UITableView, cellForRowAtIndexPath: NSIndexPath) -> UITableViewCell)?
+    open var configureCell:((_ tableView: UITableView, _ cellForRowAtIndexPath: IndexPath) -> UITableViewCell)?
     
     /// Font for the text suggestions
-    public var autoCompleteTextFont = UIFont.systemFontOfSize(12)
+    open var autoCompleteTextFont = UIFont.systemFont(ofSize: 12)
     /// Color of the text suggestions
-    public var autoCompleteTextColor = UIColor.blackColor()
+    open var autoCompleteTextColor = UIColor.black
     /// Used to set the height of cell for each suggestions
-    public var autoCompleteCellHeight:CGFloat = 44.0
+    open var autoCompleteCellHeight:CGFloat = 44.0
     /// The maximum visible suggestion
-    public var maximumAutoCompleteCount = 3
+    open var maximumAutoCompleteCount = 3
     /// Used to set your own preferred separator inset
-    public var autoCompleteSeparatorInset = UIEdgeInsetsZero
+    open var autoCompleteSeparatorInset = UIEdgeInsets.zero
     /// Shows autocomplete text with formatting
-    public var enableAttributedText = false
+    open var enableAttributedText = false
     /// User Defined Attributes
-    public var autoCompleteAttributes:[String:AnyObject]?
+    open var autoCompleteAttributes:[String:AnyObject]?
     /// Hides autocomplete tableview after selecting a suggestion
-    public var hidesWhenSelected = true
+    open var hidesWhenSelected = true
     /// Hides autocomplete tableview when the textfield is empty
-    public var hidesWhenEmpty:Bool?{
+    open var hidesWhenEmpty:Bool?{
         didSet{
             assert(hidesWhenEmpty != nil, "hideWhenEmpty cannot be set to nil")
-            autoCompleteTableView?.hidden = hidesWhenEmpty!
+            autoCompleteTableView?.isHidden = hidesWhenEmpty!
         }
     }
     /// The table view height
-    public var autoCompleteTableHeight:CGFloat?{
+    open var autoCompleteTableHeight:CGFloat?{
         didSet{
             redrawTable()
         }
     }
     /// The strings to be shown on as suggestions, setting the value of this automatically reload the tableview
-    public var autoCompleteStrings:[String]?{
+    open var autoCompleteStrings:[String]?{
         didSet{ reload() }
     }
     
@@ -67,43 +67,43 @@ public class AutoCompleteTextField:UITextField {
         super.init(coder: aDecoder)
     }
     
-    public override func awakeFromNib() {
+    open override func awakeFromNib() {
         super.awakeFromNib()
         commonInit()
         setupAutocompleteTable(superview!)
     }
     
-    public override func willMoveToSuperview(newSuperview: UIView?) {
-        super.willMoveToSuperview(newSuperview)
+    open override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
         commonInit()
         if let superview = newSuperview {
             setupAutocompleteTable(newSuperview!)
         }
     }
     
-    private func commonInit(){
+    fileprivate func commonInit(){
         hidesWhenEmpty = true
-        autoCompleteAttributes = [NSForegroundColorAttributeName:UIColor.blackColor()]
-        autoCompleteAttributes![NSFontAttributeName] = UIFont.boldSystemFontOfSize(12)
-        self.clearButtonMode = .Always
-        self.addTarget(self, action: "textFieldDidChange", forControlEvents: .EditingChanged)
-        self.addTarget(self, action: "textFieldDidEndEditing", forControlEvents: .EditingDidEnd)
+        autoCompleteAttributes = [NSForegroundColorAttributeName:UIColor.black]
+        autoCompleteAttributes![NSFontAttributeName] = UIFont.boldSystemFont(ofSize: 12)
+        self.clearButtonMode = .always
+        self.addTarget(self, action: #selector(AutoCompleteTextField.textFieldDidChange), for: .editingChanged)
+        self.addTarget(self, action: #selector(AutoCompleteTextField.textFieldDidEndEditing), for: .editingDidEnd)
     }
     
-    private func setupAutocompleteTable(view:UIView){
-        let screenSize = UIScreen.mainScreen().bounds.size
-        let tableView = UITableView(frame: CGRectMake(self.frame.origin.x, self.frame.origin.y + CGRectGetHeight(self.frame) + 25, screenSize.width - (self.frame.origin.x * 1.5), 30.0))
+    fileprivate func setupAutocompleteTable(_ view:UIView){
+        let screenSize = UIScreen.main.bounds.size
+        let tableView = UITableView(frame: CGRect(x: self.frame.origin.x, y: self.frame.origin.y + self.frame.height + 25, width: screenSize.width - (self.frame.origin.x * 1.5), height: 30.0))
         tableView.dataSource = self
         tableView.delegate = self
         tableView.rowHeight = autoCompleteCellHeight
-        tableView.hidden = hidesWhenEmpty ?? true
+        tableView.isHidden = hidesWhenEmpty ?? true
         view.addSubview(tableView)
         autoCompleteTableView = tableView
         
         autoCompleteTableHeight = 100.0
     }
     
-    private func redrawTable(){
+    fileprivate func redrawTable(){
         if let autoCompleteTableView = autoCompleteTableView, let autoCompleteTableHeight = autoCompleteTableHeight {
             var newFrame = autoCompleteTableView.frame
             newFrame.size.height = autoCompleteTableHeight
@@ -112,18 +112,18 @@ public class AutoCompleteTextField:UITextField {
     }
     
     //MARK: - Private Methods
-    private func reload(){
+    fileprivate func reload(){
         if enableAttributedText{
-            let attrs = [NSForegroundColorAttributeName:autoCompleteTextColor, NSFontAttributeName:autoCompleteTextFont]
+            let attrs = [NSForegroundColorAttributeName:autoCompleteTextColor, NSFontAttributeName:autoCompleteTextFont] as [String : Any]
     
             if attributedAutoCompleteStrings.count > 0 {
-                attributedAutoCompleteStrings.removeAll(keepCapacity: false)
+                attributedAutoCompleteStrings.removeAll(keepingCapacity: false)
             }
             
             if let autoCompleteStrings = autoCompleteStrings, let autoCompleteAttributes = autoCompleteAttributes {
                 for i in 0..<autoCompleteStrings.count{
                     let str = autoCompleteStrings[i] as NSString
-                    let range = str.rangeOfString(text!, options: .CaseInsensitiveSearch)
+                    let range = str.range(of: text!, options: .caseInsensitive)
                     let attString = NSMutableAttributedString(string: autoCompleteStrings[i], attributes: attrs)
                     attString.addAttributes(autoCompleteAttributes, range: range)
                     attributedAutoCompleteStrings.append(attString)
@@ -140,40 +140,40 @@ public class AutoCompleteTextField:UITextField {
         
         onTextChange(text!)
         if text!.isEmpty{ autoCompleteStrings = nil }
-        dispatch_async(dispatch_get_main_queue(), { () -> Void in
-            self.autoCompleteTableView?.hidden =  self.hidesWhenEmpty! ? self.text!.isEmpty : false
+        DispatchQueue.main.async(execute: { () -> Void in
+            self.autoCompleteTableView?.isHidden =  self.hidesWhenEmpty! ? self.text!.isEmpty : false
         })
     }
     
     func textFieldDidEndEditing() {
-        autoCompleteTableView?.hidden = true
+        autoCompleteTableView?.isHidden = true
     }
 }
 
 //MARK: - UITableViewDataSource - UITableViewDelegate
 extension AutoCompleteTextField: UITableViewDataSource, UITableViewDelegate {
   
-    public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return autoCompleteStrings != nil ? (autoCompleteStrings!.count > maximumAutoCompleteCount ? maximumAutoCompleteCount : autoCompleteStrings!.count) : 0
     }
     
-    public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if let configureCell = configureCell {
-            return configureCell(tableView: tableView, cellForRowAtIndexPath: indexPath)
+            return configureCell(tableView, indexPath)
         } else {
             let cellIdentifier = "autocompleteCellIdentifier"
-            var cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier)
+            var cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)
             if cell == nil{
-                cell = UITableViewCell(style: .Default, reuseIdentifier: cellIdentifier)
+                cell = UITableViewCell(style: .default, reuseIdentifier: cellIdentifier)
             }
             
             if enableAttributedText{
-                cell?.textLabel?.attributedText = attributedAutoCompleteStrings[indexPath.row]
+                cell?.textLabel?.attributedText = attributedAutoCompleteStrings[(indexPath as NSIndexPath).row]
             }
             else{
                 cell?.textLabel?.font = autoCompleteTextFont
                 cell?.textLabel?.textColor = autoCompleteTextColor
-                cell?.textLabel?.text = autoCompleteStrings![indexPath.row]
+                cell?.textLabel?.text = autoCompleteStrings![(indexPath as NSIndexPath).row]
             }
             
             cell?.contentView.gestureRecognizers = nil
@@ -181,32 +181,32 @@ extension AutoCompleteTextField: UITableViewDataSource, UITableViewDelegate {
         }
     }
     
-    public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let cell = tableView.cellForRowAtIndexPath(indexPath)
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let cell = tableView.cellForRow(at: indexPath)
         
         if let selectedText = cell?.textLabel?.text {
             self.text = selectedText
             onSelect(selectedText, indexPath)
         }
         
-        dispatch_async(dispatch_get_main_queue(), { () -> Void in
-            tableView.hidden = self.hidesWhenSelected
+        DispatchQueue.main.async(execute: { () -> Void in
+            tableView.isHidden = self.hidesWhenSelected
         })
     }
     
-    public func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
-        if cell.respondsToSelector("setSeparatorInset:"){
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if cell.responds(to: #selector(setter: UITableViewCell.separatorInset)){
             cell.separatorInset = autoCompleteSeparatorInset
         }
-        if cell.respondsToSelector("setPreservesSuperviewLayoutMargins:"){
+        if cell.responds(to: #selector(setter: UIView.preservesSuperviewLayoutMargins)){
             cell.preservesSuperviewLayoutMargins = false
         }
-        if cell.respondsToSelector("setLayoutMargins:"){
+        if cell.responds(to: #selector(setter: UIView.layoutMargins)){
             cell.layoutMargins = autoCompleteSeparatorInset
         }
     }
     
-    public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return autoCompleteCellHeight
     }
 }

--- a/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
+++ b/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
@@ -76,7 +76,9 @@ public class AutoCompleteTextField:UITextField {
     public override func willMoveToSuperview(newSuperview: UIView?) {
         super.willMoveToSuperview(newSuperview)
         commonInit()
-        setupAutocompleteTable(newSuperview!)
+        if let superview = newSuperview {
+            setupAutocompleteTable(newSuperview!)
+        }
     }
     
     private func commonInit(){
@@ -90,7 +92,7 @@ public class AutoCompleteTextField:UITextField {
     
     private func setupAutocompleteTable(view:UIView){
         let screenSize = UIScreen.mainScreen().bounds.size
-        let tableView = UITableView(frame: CGRectMake(self.frame.origin.x, self.frame.origin.y + CGRectGetHeight(self.frame), screenSize.width - (self.frame.origin.x * 2), 30.0))
+        let tableView = UITableView(frame: CGRectMake(self.frame.origin.x, self.frame.origin.y + CGRectGetHeight(self.frame) + 25, screenSize.width - (self.frame.origin.x * 1.5), 30.0))
         tableView.dataSource = self
         tableView.delegate = self
         tableView.rowHeight = autoCompleteCellHeight


### PR DESCRIPTION
This PR has two features:
- Add a podspec-file to use with CocoaPods
- Add a `configureCell` callback to allow complete configuration of the table cell
  For example I use it to create a two-column cell for stock ticker symbols. The first column is the ticker symbol and the second column is the company name.
